### PR TITLE
Add docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 # Decaf
 Decaf is the Mugsy JSON API. And at least for now, that stands for *Does Every Coffee Action, Friend*. 
 
+## Install on Raspbian
+
 Current Requirements:
+
  - Python 3
  - MySQL
  - Pip3
 
-Install(instructions in progress): 
+Install(instructions in progress):
+
  - sudo pip3 install Flask
  - sudo pip3 install Flask-RESTful
  - sudo pip3 install Flask-MySQL
@@ -59,4 +63,12 @@ This turns on pin 23 which is connected to relay channel 1 for 2 seconds, it rep
 
 
  ### Please note that this runs decaf on the Flask development server and is not meant for production!
+
+## Run on Docker on Raspbian
+
+1. Install Git and [Docker CE](https://docs.docker.com/install/linux/docker-ce/ubuntu/#install-using-the-convenience-script)
+2. `git clone https://github.com/margyle/decaf.git && cd decaf`
+3. Edit config file as above. `dbhost = 'localhost'`, `dbuser = 'root'`, `dbpass = ''`, `dbdb = 'mugsy'`
+4. `docker build -t heymugsy .`
+5. `docker run -it --rm -p 5000:5000 -v /var/lib/mysql heymugsy`
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ dbhost = '************'
  dont forget to change the ip to your Pi's IP, or local host if your are browsing from the pi itself.
 
 #### Relay control formatting:
-```
+
 It currently requires 6 arguments:
 * pinNumber
 * relayChannel


### PR DESCRIPTION
This should be all you need to get going with Docker.

Things to note:
* I've called the image "heymugsy", but you could call it whatever you like. ("margyle/mugsy", "mugsy/decaf"...)
* The `run` command runs the container in the foreground, and removes the container when you exit out (Ctrl + C). This is probably fine/ideal for development, but you'd probably want to run it in the background for Production.
* I didn't bother setting up a MySQL user. It just uses `root` with no password.
* I had to mount `/var/lib/mysql` as a volume on the host for some reason (it's what Google told me). Actually, installing MySql and Flask-MySql was by far the most painful bit. I think you should consider SQLite, as was brought up a while back. It would remove the need for editing the config file too.