### PR TITLE
Get GPIO working on docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,9 @@ RUN virtualenv decaf
 
 RUN /decaf/bin/pip3 install Flask Flask-RESTful Flask-MySQL simplejson RPi.GPIO
 
-COPY ./ /var/www/decaf
+COPY ./ /var/mugsy/decaf
 
-WORKDIR /var/www/decaf
+WORKDIR /var/mugsy/decaf
 
 ENTRYPOINT /etc/init.d/mysql start && \
            mysql < db/mugsy.sql && \

--- a/README.md
+++ b/README.md
@@ -74,5 +74,5 @@ http://192.168.1.183:5000/pinInfo/grinder
 2. `git clone https://github.com/margyle/decaf.git && cd decaf`
 3. Edit config file as above. `dbhost = 'localhost'`, `dbuser = 'root'`, `dbpass = ''`, `dbdb = 'mugsy'`
 4. `docker build -t heymugsy .`
-5. `docker run -it --rm -p 5000:5000 -v /var/lib/mysql heymugsy`
+5. `docker run -it --rm --privileged -p 5000:5000 -v /var/lib/mysql heymugsy`
 


### PR DESCRIPTION
These tweaks are needed to get the `relayControl` endpoint working in Docker.