### PR TITLE
Add type annotations to route parameters

### DIFF
--- a/decaf.py
+++ b/decaf.py
@@ -44,7 +44,7 @@ api.add_resource(brewSettings, '/BrewSettings/<int:userId>')
 api.add_resource(coffeeInfo, '/CoffeeInfo/<int:coffeeTypeId>')
 api.add_resource(barCode, '/barcodeScanner/', methods=['GET'])
 api.add_resource(pinInfo, '/pinInfo/<hardwareType>')
-api.add_resource(relayController, '/relayControl/<int:pinNumber>/<int:relayChannel>/<float:timeOn>/<int:repeatValue>/<int:repeatDelay>/<string:connectedHardware>')
+api.add_resource(relayController, '/relayControl/<int:pinNumber>/<int:relayChannel>/<timeOn>/<int:repeatValue>/<int:repeatDelay>/<string:connectedHardware>')
 
 
 if __name__ == "__main__":

--- a/decaf.py
+++ b/decaf.py
@@ -40,11 +40,11 @@ class pinInfo(Resource):
 	def get(self, hardwareType):
 		return {'pinMappings': pinMappings.get(hardwareType)}
 
-api.add_resource(brewSettings, '/BrewSettings/<userId>')
-api.add_resource(coffeeInfo, '/CoffeeInfo/<coffeeTypeId>')
+api.add_resource(brewSettings, '/BrewSettings/<int:userId>')
+api.add_resource(coffeeInfo, '/CoffeeInfo/<int:coffeeTypeId>')
 api.add_resource(barCode, '/barcodeScanner/', methods=['GET'])
 api.add_resource(pinInfo, '/pinInfo/<hardwareType>')
-api.add_resource(relayController, '/relayControl/<pinNumber>/<relayChannel>/<timeOn>/<repeatValue>/<repeatDelay>/<connectedHardware>')
+api.add_resource(relayController, '/relayControl/<int:pinNumber>/<int:relayChannel>/<float:timeOn>/<int:repeatValue>/<int:repeatDelay>/<string:connectedHardware>')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This should mean that you don't need to cast the parameters to the correct type when you use them.