### PR TITLE
Fix requirements.txt Docker integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,11 @@ RUN pip3 install virtualenv
 
 RUN virtualenv decaf
 
-RUN /decaf/bin/pip3 install -r requirements.txt
-
-COPY ./ /var/mugsy/decaf
+COPY . /var/mugsy/decaf
 
 WORKDIR /var/mugsy/decaf
+
+RUN /decaf/bin/pip3 install -r requirements.txt
 
 ENTRYPOINT /etc/init.d/mysql start && \
            mysql < db/mugsy.sql && \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Flask==1.0.2
-Flask-MySQL==1.4.0
-Flask-RESTful==0.3.6
+Flask_RESTful==0.3.6
 simplejson==3.16.0
+Flask==1.0.2
+Flask_Bcrypt==0.7.1
 RPi.GPIO==0.6.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-Flask_RESTful==0.3.6
-simplejson==3.16.0
 Flask==1.0.2
+Flask_RESTful==0.3.6
 Flask_Bcrypt==0.7.1
+Flask-MySQL==1.4.0
+simplejson==3.16.0
 RPi.GPIO==0.6.5


### PR DESCRIPTION
Realized I could run the docker image on my mac. Identified an issue with loading requirements.txt into the docker image before the file was copied over. Moreover, generated a definitive list of packages with `pipreqs`.